### PR TITLE
Added some more switches, similar to Neno's TfsCreateBuild, for changesets and workitems

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,29 +13,33 @@ TfsBuildResultPublisher allows you to create a Fake build, and publish test resu
                        /buildnumber:"MyApplication_Daily_1.0"
 
     Options:
-    -c, --collection=VALUE         The collection
-    -p, --project=VALUE            The team project
-    -b, --builddefinition=VALUE    The build definition
-    -n, --buildnumber=VALUE        The build number to assign the build\
-    -s, --status=VALUE             Status of the build  (Succeeded, Failed, Stopped, PartiallySucceeded, default: Succeeded)
-    -f, --flavor=VALUE             Flavor of the build (to track test results against, default: Debug)
-    -l, --platform=VALUE           Platform of the build (to track test results against, AnyCPU)
-    -t, --target=VALUE             Target of the build (shown on build report, default: default)
-      --localpath=VALUE            Local path of solution file. (default: Solutio                               n.sln)
-      --serverpath=VALUE           Version Control path for solution file. (e.g. $/Solution.sln)
-      --droplocation=VALUE         Location where builds are dropped (default: \\server\drops\)
-      --buildlog=VALUE             Location of build log file. (e.g. \\server\folder\build.log)
-      --testResults=VALUE          Test results file to publish (*.trx, requires MSTest installed)
-      --create                     Should the build definition be created if it does not exist
-      --trigger                    Instead of creating a manual build, we should trigger the build
-      --keepForever                Does the build participates in the retention policy of the build definition or to keep the                                build forever
-      --buildController=VALUE      The name of the build controller to use when creating the build definition (default, first controller)
-      --publishTestRun             Creates a test run in Test Manager (requires tcm.exe installed)
-      --fixTestIds                 If the .trx file comes from VSTest.Console.exe, the testId's will not be recognised by Test Runs (for associated automation)
-      --testSuiteId=VALUE          The Test Suite to publish the results of the test run to [tcm /suiteId]
-      --testConfigid=VALUE         The Test Configuration to publish the results of the test run to [tcm /configId]
-      --testRunTitle=VALUE         The title of the test run [tcm /title]
-      --testRunResultOwner=VALUE   The result owner of the test run [tcm /resultOwner]
+    -c, --collection=VALUE                 The collection
+    -p, --project=VALUE                    The team project
+    -b, --builddefinition=VALUE            The build definition
+    -n, --buildnumber=VALUE                The build number to assign the build\
+    -s, --status=VALUE                     Status of the build  (Succeeded, Failed, Stopped, PartiallySucceeded, default: Succeeded)
+    -f, --flavor=VALUE                     Flavor of the build (to track test results against, default: Debug)
+    -l, --platform=VALUE                   Platform of the build (to track test results against, AnyCPU)
+    -t, --target=VALUE                     Target of the build (shown on build report, default: default)
+      --localpath=VALUE                    Local path of solution file. (default: Solutio                               n.sln)
+      --serverpath=VALUE                   Version Control path for solution file. (e.g. $/Solution.sln)
+      --droplocation=VALUE                 Location where builds are dropped (default: \\server\drops\)
+      --buildlog=VALUE                     Location of build log file. (e.g. \\server\folder\build.log)
+      --testResults=VALUE                  Test results file to publish (*.trx, requires MSTest installed)
+      --create                             Should the build definition be created if it does not exist
+      --trigger                            Instead of creating a manual build, we should trigger the build
+      --keepForever                        Does the build participates in the retention policy of the build definition or to keep the                                build forever
+      --buildController=VALUE              The name of the build controller to use when creating the build definition (default, first controller)
+      --publishTestRun                     Creates a test run in Test Manager (requires tcm.exe installed)
+      --fixTestIds                         If the .trx file comes from VSTest.Console.exe, the testId's will not be recognised by Test Runs (for associated automation)
+      --testSuiteId=VALUE                  The Test Suite to publish the results of the test run to [tcm /suiteId]
+      --testConfigid=VALUE                 The Test Configuration to publish the results of the test run to [tcm /configId]
+      --testRunTitle=VALUE                 The title of the test run [tcm /title]
+      --testRunResultOwner=VALUE           The result owner of the test run [tcm /resultOwner]
+      --changeSets=VALUE                   The changeset Id's to associate the build with (value is comma delimited: 1,2,3)
+      --workItems=VALUE                    The workiem Id's to associate the build with (value is comma delimited: 1,2,3)
+      --autoAssocChangesetWorkItems=VALUE  Whether to auto-associate changeset workitems to the build (true if a value is present)
+      --buildQueueDisabled=VALUE           Whether the build definition's queue is created disabled (true if a value is present)
 
 ## References
 **Original Blog post:** [http://blogs.msdn.com/b/jpricket/archive/2010/02/23/creating-fake-builds-in-tfs-build-2010.aspx](http://blogs.msdn.com/b/jpricket/archive/2010/02/23/creating-fake-builds-in-tfs-build-2010.aspx)  

--- a/TfsCreateBuild/BuildCreator.cs
+++ b/TfsCreateBuild/BuildCreator.cs
@@ -40,7 +40,8 @@ namespace TfsBuildResultPublisher
                     configuration.BuildStatus, configuration.Collection, configuration.BuildLog, configuration.DropPath, configuration.BuildFlavor,
                     configuration.LocalPath, configuration.BuildPlatform, configuration.BuildTarget, configuration.Project, configuration.BuildDefinition,
                     configuration.CreateBuildDefinitionIfNotExists, configuration.BuildController, configuration.BuildNumber, configuration.ServerPath,
-                    configuration.KeepForever);
+                    configuration.KeepForever, configuration.AssociatedChangesetIds, configuration.AssociatedWorkitemIds, configuration.AutoIncludeChangesetWorkItems,
+                    configuration.BuildQueueDisabled);
             }
 
             if (!string.IsNullOrEmpty(configuration.TestResults) && File.Exists(configuration.TestResults))

--- a/TfsCreateBuild/BuildTestResultPublisher.cs
+++ b/TfsCreateBuild/BuildTestResultPublisher.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 
 namespace TfsBuildResultPublisher
 {
@@ -10,10 +11,12 @@ namespace TfsBuildResultPublisher
         {
             var paths = new[]
                 {
+                    @"C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\MSTest.exe",
+                    @"C:\Program Files\Microsoft Visual Studio 14.0\Common7\IDE\MSTest.exe",
                     @"C:\Program Files (x86)\Microsoft Visual Studio 11.0\Common7\IDE\MSTest.exe",
                     @"C:\Program Files\Microsoft Visual Studio 11.0\Common7\IDE\MSTest.exe"
                 };
-            var msTest = File.Exists(paths[0]) ? paths[0] : paths[1];
+            var msTest = paths.FirstOrDefault(File.Exists);
             const string argsFormat = "/publish:\"{0}\" /publishresultsfile:\"{1}\" /teamproject:\"{2}\" /publishbuild:\"{3}\" /platform:\"{4}\" /flavor:\"{5}\"";
             var args = string.Format(argsFormat, collection, testResultsFile, project, buildNumber, buildPlatform, buildFlavour);
             string stdOut;

--- a/TfsCreateBuild/Configuration.cs
+++ b/TfsCreateBuild/Configuration.cs
@@ -29,5 +29,9 @@
         public string TeamCityPassword { get; set; }
         public bool TriggerBuild { get; set; }
         public bool KeepForever { get; set; }
+        public int[] AssociatedChangesetIds { get; set; }
+        public int[] AssociatedWorkitemIds { get; set; }
+        public bool AutoIncludeChangesetWorkItems { get; set; }
+        public bool BuildQueueDisabled { get; set; }
     }
 }

--- a/TfsCreateBuild/ConfigurationProvider.cs
+++ b/TfsCreateBuild/ConfigurationProvider.cs
@@ -45,6 +45,10 @@ namespace TfsBuildResultPublisher
                     {"testConfigid=", @"The Test Configuration to publish the results of the test run to [tcm /configId]", v => localConfiguration.TestConfigId = int.Parse(v)},
                     {"testRunTitle=", @"The title of the test run [tcm /title]", v => localConfiguration.TestRunTitle = v},
                     {"testRunResultOwner=", @"The result owner of the test run [tcm /resultOwner]", v => localConfiguration.TestRunResultOwner = v},
+                    {"changeSets=", @"The changeset Id's to associate the build with", v => localConfiguration.AssociatedChangesetIds = Array.ConvertAll(v.Split(new[]{','}, StringSplitOptions.RemoveEmptyEntries), int.Parse)},
+                    {"workItems=", @"The workiem Id's to associate the build with", v => localConfiguration.AssociatedWorkitemIds = Array.ConvertAll(v.Split(new[]{','}, StringSplitOptions.RemoveEmptyEntries), int.Parse)},
+                    {"autoAssocChangesetWorkItems=", @"Whether to auto-associate changeset workitems to the build", v => localConfiguration.AutoIncludeChangesetWorkItems = (v !=null)},
+                    {"buildQueueDisabled=", @"Whether the build definition's queue is disabled", v => localConfiguration.BuildQueueDisabled = (v !=null)},
                 };
 
             try

--- a/TfsCreateBuild/ITfsManualBuildCreator.cs
+++ b/TfsCreateBuild/ITfsManualBuildCreator.cs
@@ -2,6 +2,6 @@
 {
     public interface ITfsManualBuildCreator
     {
-        void CreateManualBuild(string buildStatus, string collection, string buildLog, string dropPath, string buildFlavour, string localPath, string buildPlatform, string buildTarget, string project, string buildDefinition, bool createBuildDefinitionIfNotExists, string buildController, string buildNumber, string serverPath, bool keepForever);
+        void CreateManualBuild(string buildStatus, string collection, string buildLog, string dropPath, string buildFlavour, string localPath, string buildPlatform, string buildTarget, string project, string buildDefinition, bool createBuildDefinitionIfNotExists, string buildController, string buildNumber, string serverPath, bool keepForever, int[] associatedChangesetIds, int[] associatedWorkitemIds, bool autoIncludeChangesetWorkItems, bool buildQueueDisabled);
     }
 }

--- a/TfsCreateBuild/TfsBuildResultPublisher.csproj
+++ b/TfsCreateBuild/TfsBuildResultPublisher.csproj
@@ -58,6 +58,9 @@
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.TestManagement.Client, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.TeamFoundation.TestManagement.Common, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.TeamFoundation.VersionControl.Client, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.TeamFoundation.WorkItemTracking.Client, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.TeamFoundation.WorkItemTracking.Common, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="NDesk.Options">
       <HintPath>..\packages\NDesk.Options.0.2.1\lib\NDesk.Options.dll</HintPath>
     </Reference>
@@ -102,7 +105,9 @@
     <Compile Include="TrxFileCorrector.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
     <None Include="TfsCreateBuild.nuspec">
       <SubType>Designer</SubType>

--- a/TfsCreateBuild/app.config
+++ b/TfsCreateBuild/app.config
@@ -1,3 +1,46 @@
 <?xml version="1.0"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
+  </startup>
+  <!-- Uncomment to re-bind to the TFS 2013 libraries 
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.TeamFoundation.Client" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.TeamFoundation.Build.Client" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.TeamFoundation.VersionControl.Client" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.TeamFoundation.WorkItemTracking.Client" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.TeamFoundation.Build.Common" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.TeamFoundation.WorkItemTracking.Common" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  -->
+</configuration>


### PR DESCRIPTION
- Added support for /changesets=int[] and /workitems=int[] similar to http://blogs.msmvps.com/vstsblog/2011/04/26/creating-fake-builds-in-tfs-build-2010-using-the-command-line/
- Added support for /autoAssocChangesetWorkItems=true to auto-associate changeset workitems to the build
- Added support for /buildQueueDisabled=true  to create the build defintion with a disabled queue, to stop users queueing builds.
- Added app.config commented out binding re-directs for using the TFS2013 assemblies
